### PR TITLE
feat: Add npx support for CLI execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "mcp",
+  "name": "@elizabethtrykin/oura-mcp",
   "version": "1.0.0",
-  "main": "index.js",
-  "keywords": [],
+  "main": "build/index.js",
+  "keywords": ["oura", "mcp", "modelcontextprotocol"],
   "author": "",
   "license": "ISC",
-  "description": "",
+  "description": "MCP server for Oura Ring API",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
     "dotenv": "^16.4.7",
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "bin": {
-    "weather": "./build/index.js"
+    "oura-mcp": "./build/index.js"
   },
   "scripts": {
     "build": "tsc && chmod 755 build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { config as dotenvConfig } from 'dotenv';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { OuraProvider } from './provider/oura_provider.js';


### PR DESCRIPTION
## Summary
This PR adds support for running the Oura MCP server directly via npx, making it easier for users to integrate with Claude Desktop and other MCP clients.

## Changes
- ✨ Update package name to scoped `@elizabethtrykin/oura-mcp` for npm publishing
- 📝 Add shebang (`#!/usr/bin/env node`) to enable direct CLI execution
- 🔧 Configure bin field to register `oura-mcp` command
- 📦 Update main field to correctly point to build output
- 🏷️ Add descriptive keywords and package description

## Testing
After building with `npm run build`, the package can be tested locally:
```bash
npm link
npx oura-mcp
```

## Publishing Instructions
After merging, you can publish to npm to enable npx usage:

1. **Setup npm account**
   ```bash
   npm login
   ```

2. **Build and publish**
   ```bash
   npm run build
   npm publish --access public
   ```

3. **Usage**
   Users can then run:
   ```bash
   npx @elizabethtrykin/oura-mcp
   ```

4. **Claude Desktop Configuration**
   Users can add to their Claude Desktop config:
   ```json
   {
     "mcpServers": {
       "oura": {
         "command": "npx",
         "args": ["@elizabethtrykin/oura-mcp"],
         "env": {
           "OURA_PERSONAL_ACCESS_TOKEN": "user-token-here"
         }
       }
     }
   }
   ```

This makes the MCP server much more accessible without requiring users to clone and build the repository locally.